### PR TITLE
new metadata 'fatgs' to create a #tag on a Fediverse post only

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Hashtag(s) are taken - if any - from `article.tags` and concatenated separating 
 
 Pelican can nicely handle tags with whitespaces (for example `#My nice article`) but in Mastodon they must be written without. For this reason all whitespaces from Pelican hashtags will be removed before publishing (`#Mynicearticle`).
 
+### New metadata **ftags**
+You can use the `ftags` metadata to add specific tags to a Fediverse post without including Pelican hashtags.
+```markdown
+Title: This is a ftags sample usage
+Date: 2025-05-23
+Slug: ftags-sample
+tags: tag_on_blog_and_fediverse, another_one
+ftags: TagOnlyOnFediverse, SecondOne
+
+```
+
 ## Mastodon APIs
 
 This plugin depends on [Mastodon.py](https://github.com/halcy/Mastodon.py).

--- a/fediverse.py
+++ b/fediverse.py
@@ -113,27 +113,33 @@ def post_updates(generator, writer):
             articlecleantext = html.fromstring(articlehtmltext)
             summary_to_publish = articlecleantext.text_content().strip() + '\n'
             read_more = mt_read_more + article.get_siteurl() + '/' + article.url + '\n\n'
+
+            fedi_tag_list = []
+            tags_to_publish = ''
+
+            if hasattr(article, 'ftags'):
+               for ftag in article.ftags.split(','):
+                  fedi_tag_list.append('#' + ftag.replace(' ', ''))
+
             if hasattr(article, 'tags'):
-               taglist = article.tags
-               new_taglist = []
-               for i in taglist:
-                  new_taglist.append('#' + str(i))
-                  tags_to_publish = ', '.join(str(x).replace(" ", "") for x in new_taglist)
-               toot_length = len(title_to_publish) + len(summary_to_publish) + len(read_more) + len(tags_to_publish)
-               if toot_length > toot_maxlength:
-                  truncate = toot_maxlength - len(title_to_publish) - len(tags_to_publish) - len(read_more) - 4
-                  summary_to_publish = summary_to_publish[:truncate] + ' ...' + '\n'
-                  mastodon_toot = title_to_publish + summary_to_publish + read_more + tags_to_publish
-               else:
-                  mastodon_toot = title_to_publish + summary_to_publish + read_more + tags_to_publish
-            else:
-               toot_length = len(title_to_publish) + len(summary_to_publish) + len(read_more)
-               if toot_length > toot_maxlength:
-                  truncate = toot_maxlength - len(title_to_publish) - len(read_more) - 4
-                  summary_to_publish = summary_to_publish[:truncate] + ' ...' + '\n'
-                  mastodon_toot = title_to_publish + summary_to_publish + read_more
-               else:
-                  mastodon_toot = title_to_publish + summary_to_publish + read_more
+               for tag in article.tags:
+                  fedi_tag_list.append('#' + str(tag).replace(' ',''))
+
+            if fedi_tag_list:
+               tags_to_publish = ', '.join(fedi_tag_list)
+
+            toot_length = (len(title_to_publish)  +
+                           len(summary_to_publish) +
+                           len(read_more) +
+                           len(tags_to_publish))
+
+            if toot_length > toot_maxlength:
+               truncate = (toot_maxlength - len(title_to_publish) -
+                           len(tags_to_publish) - len(read_more) - 4)
+               summary_to_publish = summary_to_publish[
+                                    :truncate] + ' ...' + '\n'
+
+            mastodon_toot = title_to_publish + summary_to_publish + read_more + tags_to_publish
 
             mastodon.status_post(mastodon_toot, visibility=mt_visibility)
 


### PR DESCRIPTION
feat: create new metadata 'fatgs' to create a #tag on a Fediverse post that is not included in the Pelican article