### PR TITLE
feat: add parameter to set same hastags for all fediverse posts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,19 @@ On every run *Fediverse* looks for a file called `pelicanfediverse_clientcred.se
 If you **cancel** this file *Fediverse* will create another app on its next run (this could be done in case of problem despite the fact Mastodon advise this is NOT a good behaviour since app should be created only once).
 
 
-## parameters
+## Parameters
 
 In `pelicanconf.py` some new parameters can be defined
 
- - **MASTODON_VISIBILITY** : Set post's visiblity on mastodon. Can be 'direct', 'private', 'unlisted' or 'public'. Default value = 'direct' 
-
-  More details : https://mastodonpy.readthedocs.io/en/stable/05_statuses.html#writing
+ - **MASTODON_VISIBILITY** : Set post's visiblity on mastodon. Can be 'direct', 'private', 'unlisted' or 'public'. Default value = 'direct'
+  <br>More details : https://mastodonpy.readthedocs.io/en/stable/05_statuses.html#writing
   
  - **MASTODON_READ_MORE** : Text to add at the end of the post, before link to the pelican's article. Default value = 'Read more: '
 
+ - **FEDIVERSE_TAGS** : To add same tag on all fediverse post but not on blog post. It is possible to set multiple tags with comma separator. _(ie "MyFirstTag, AnotherOne" generate **#MyFirstTag** and **#AnotherOne**)_
+
 ``` Python
-MASTODON_VISIBILITY='direct'
-MASTODON_READ_MORE='Read more: '
+MASTODON_VISIBILITY = 'direct'
+MASTODON_READ_MORE = 'Read more: '
+FEDIVERSE_TAGS = 'FromMyBlog'
+```

--- a/fediverse.py
+++ b/fediverse.py
@@ -52,6 +52,9 @@ def post_on_mastodon(settings, new_posts):
    global mt_visibility
    mt_visibility = settings.get('MASTODON_VISIBILITY', 'direct')
 
+   global mt_fediverse_tags
+   mt_fediverse_tags = settings.get('FEDIVERSE_TAGS', '')
+
    # check if config file contains username and password and prompt the user this is deprecated
    if mt_username or mt_password in globals():
       logger.warning('Pelican_fediverse: password authentication is DEPRECATED and will be removed soon!\nPlease use OAuth token instead...')
@@ -116,6 +119,11 @@ def post_updates(generator, writer):
 
             fedi_tag_list = []
             tags_to_publish = ''
+
+            # if FEDIVERSE_TAGS is set in pelicanconf.py, add tags to the post
+            if mt_fediverse_tags != '':
+               for tag in mt_fediverse_tags.split(','):
+                  fedi_tag_list.append('#' + tag.replace(' ', ''))
 
             if hasattr(article, 'ftags'):
                for ftag in article.ftags.split(','):


### PR DESCRIPTION
New parameter "FEDIVERSE_TAGS" to set tags on all Ferdiverse posts.
These tags do not generate hastags (or label) on Pelican posts.

fix #5